### PR TITLE
Allow customizing through relations local keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,30 @@ class Comment extends Model
 }
 ```
 
+You can specify custom local keys for the relations:
+
+`VendorCustomerAddress` → belongs to → `VendorCustomer` in `VendorCustomerAddress.vendor_customer_id`
+`VendorCustomerAddress` → belongs to → `CustomerAddress` in `VendorCustomerAddress.address_id`
+
+You can access `VendorCustomer` from `CustomerAddress` by the following
+
+```php
+class CustomerAddress extends Model
+{
+    use \Znck\Eloquent\Traits\BelongsToThrough;
+
+    public function vendorCustomer(): BelongsToThrough
+    {
+        return $this->belongsToThrough(
+            VendorCustomer::class,
+            VendorCustomerAddress::class,
+            foreignKeyLookup: [VendorCustomerAddress::class => 'id'],
+            localKeyLookup: [VendorCustomerAddress::class => 'address_id'],
+        );
+    }    
+}
+```
+
 ### Table Aliases
 
 If your relationship path contains the same model multiple times, you can specify a table alias (Laravel 6+):

--- a/src/Relations/BelongsToThrough.php
+++ b/src/Relations/BelongsToThrough.php
@@ -144,12 +144,12 @@ class BelongsToThrough extends Relation
     /**
      * Get the local key for a model.
      *
-     * @param \Illuminate\Database\Eloquent\Model|null $model
+     * @param \Illuminate\Database\Eloquent\Model $model
      * @return string
      */
-    public function getLocalKeyName(Model $model = null): string
+    public function getLocalKeyName(Model $model): string
     {
-        $table = explode(' as ', ($model ?? $this->parent)->getTable())[0];
+        $table = explode(' as ', $model->getTable())[0];
 
         if (array_key_exists($table, $this->localKeyLookup)) {
             return $this->localKeyLookup[$table];

--- a/src/Relations/BelongsToThrough.php
+++ b/src/Relations/BelongsToThrough.php
@@ -43,7 +43,7 @@ class BelongsToThrough extends Relation
     protected $foreignKeyLookup;
 
     /**
-     * The custom foreign keys on the relationship.
+     * The custom local keys on the relationship.
      *
      * @var array
      */
@@ -62,8 +62,15 @@ class BelongsToThrough extends Relation
      *
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, array $throughParents, $localKey = null, $prefix = '', array $foreignKeyLookup = [], array $localKeyLookup = [])
-    {
+    public function __construct(
+        Builder $query,
+        Model $parent,
+        array $throughParents,
+        $localKey = null,
+        $prefix = '',
+        array $foreignKeyLookup = [],
+        array $localKeyLookup = []
+    ) {
         $this->throughParents = $throughParents;
         $this->prefix = $prefix;
         $this->foreignKeyLookup = $foreignKeyLookup;
@@ -135,11 +142,12 @@ class BelongsToThrough extends Relation
     }
 
     /**
-     * Get the foreign key for a model.
+     * Get the local key for a model.
      *
+     * @param \Illuminate\Database\Eloquent\Model|null $model
      * @return string
      */
-    public function getLocalKeyName(Model $model = null)
+    public function getLocalKeyName(Model $model = null): string
     {
         $table = explode(' as ', ($model ?? $this->parent)->getTable())[0];
 
@@ -345,10 +353,10 @@ class BelongsToThrough extends Relation
     }
 
     /**
-      * Get the qualified local key for the first "through" parent model.
-      *
-      * @return string
-      */
+     * Get the qualified local key for the first "through" parent model.
+     *
+     * @return string
+     */
     public function getQualifiedFirstLocalKeyName()
     {
         return end($this->throughParents)->qualifyColumn($this->getLocalKeyName(end($this->throughParents)));

--- a/src/Relations/BelongsToThrough.php
+++ b/src/Relations/BelongsToThrough.php
@@ -155,7 +155,7 @@ class BelongsToThrough extends Relation
             return $this->localKeyLookup[$table];
         }
 
-        return 'id';
+        return $model->getKeyName();
     }
 
     /**
@@ -359,7 +359,9 @@ class BelongsToThrough extends Relation
      */
     public function getQualifiedFirstLocalKeyName()
     {
-        return end($this->throughParents)->qualifyColumn($this->getLocalKeyName(end($this->throughParents)));
+        $lastThroughParent = end($this->throughParents);
+
+        return $lastThroughParent->qualifyColumn($this->getLocalKeyName($lastThroughParent));
     }
 
     /**

--- a/src/Traits/BelongsToThrough.php
+++ b/src/Traits/BelongsToThrough.php
@@ -16,12 +16,17 @@ trait BelongsToThrough
      * @param string|null $localKey
      * @param string $prefix
      * @param array $foreignKeyLookup
-     * @param mixed $localKeyLookup
-     *
+     * @param array  $localKeyLookup
      * @return \Znck\Eloquent\Relations\BelongsToThrough
      */
-    public function belongsToThrough($related, $through, $localKey = null, $prefix = '', $foreignKeyLookup = [], $localKeyLookup = [])
-    {
+    public function belongsToThrough(
+        $related,
+        $through,
+        $localKey = null,
+        $prefix = '',
+        $foreignKeyLookup = [],
+        array $localKeyLookup = []
+    ) {
         $relatedInstance = $this->newRelatedInstance($related);
         $throughParents  = [];
         $foreignKeys     = [];
@@ -48,7 +53,15 @@ trait BelongsToThrough
 
         $localKeys = $this->mapKeys($localKeyLookup);
 
-        return $this->newBelongsToThrough($relatedInstance->newQuery(), $this, $throughParents, $localKey, $prefix, $foreignKeys, $localKeys);
+        return $this->newBelongsToThrough(
+            $relatedInstance->newQuery(),
+            $this,
+            $throughParents,
+            $localKey,
+            $prefix,
+            $foreignKeys,
+            $localKeys
+        );
     }
 
     /**
@@ -57,7 +70,7 @@ trait BelongsToThrough
      * @param array $keyLookup
      * @return array
      */
-    protected function mapKeys(array $keyLookup)
+    protected function mapKeys(array $keyLookup): array
     {
         $keys = [];
 
@@ -77,7 +90,6 @@ trait BelongsToThrough
      * Create a through parent instance for a belongs-to-through relationship.
      *
      * @param string $model
-     *
      * @return \Illuminate\Database\Eloquent\Model
      */
     protected function belongsToThroughParentInstance($model)
@@ -104,11 +116,17 @@ trait BelongsToThrough
      * @param string $prefix
      * @param array $foreignKeyLookup
      * @param array $localKeyLookup
-     *
      * @return \Znck\Eloquent\Relations\BelongsToThrough
      */
-    protected function newBelongsToThrough(Builder $query, Model $parent, array $throughParents, $localKey, $prefix, array $foreignKeyLookup, array $localKeyLookup)
-    {
+    protected function newBelongsToThrough(
+        Builder $query,
+        Model $parent,
+        array $throughParents,
+        $localKey,
+        $prefix,
+        array $foreignKeyLookup,
+        array $localKeyLookup
+    ) {
         return new Relation($query, $parent, $throughParents, $localKey, $prefix, $foreignKeyLookup, $localKeyLookup);
     }
 }

--- a/src/Traits/BelongsToThrough.php
+++ b/src/Traits/BelongsToThrough.php
@@ -16,13 +16,16 @@ trait BelongsToThrough
      * @param string|null $localKey
      * @param string $prefix
      * @param array $foreignKeyLookup
+     * @param mixed $localKeyLookup
+     *
      * @return \Znck\Eloquent\Relations\BelongsToThrough
      */
-    public function belongsToThrough($related, $through, $localKey = null, $prefix = '', $foreignKeyLookup = [])
+    public function belongsToThrough($related, $through, $localKey = null, $prefix = '', $foreignKeyLookup = [], $localKeyLookup = [])
     {
         $relatedInstance = $this->newRelatedInstance($related);
-        $throughParents = [];
-        $foreignKeys = [];
+        $throughParents  = [];
+        $foreignKeys     = [];
+        $localKeys       = [];
 
         foreach ((array) $through as $model) {
             $foreignKey = null;
@@ -50,13 +53,22 @@ trait BelongsToThrough
             }
         }
 
-        return $this->newBelongsToThrough($relatedInstance->newQuery(), $this, $throughParents, $localKey, $prefix, $foreignKeys);
+        foreach ($localKeyLookup as $model => $localKey) {
+            $instance = new $model();
+
+            if ($localKey) {
+                $localKeys[$instance->getTable()] = $localKey;
+            }
+        }
+
+        return $this->newBelongsToThrough($relatedInstance->newQuery(), $this, $throughParents, $localKey, $prefix, $foreignKeys, $localKeys);
     }
 
     /**
      * Create a through parent instance for a belongs-to-through relationship.
      *
      * @param string $model
+     *
      * @return \Illuminate\Database\Eloquent\Model
      */
     protected function belongsToThroughParentInstance($model)
@@ -67,7 +79,7 @@ trait BelongsToThrough
         $instance = new $segments[0]();
 
         if (isset($segments[1])) {
-            $instance->setTable($instance->getTable().' as '.$segments[1]);
+            $instance->setTable($instance->getTable() . ' as ' . $segments[1]);
         }
 
         return $instance;
@@ -82,10 +94,12 @@ trait BelongsToThrough
      * @param string $localKey
      * @param string $prefix
      * @param array $foreignKeyLookup
+     * @param array $localKeyLookup
+     * 
      * @return \Znck\Eloquent\Relations\BelongsToThrough
      */
-    protected function newBelongsToThrough(Builder $query, Model $parent, array $throughParents, $localKey, $prefix, array $foreignKeyLookup)
+    protected function newBelongsToThrough(Builder $query, Model $parent, array $throughParents, $localKey, $prefix, array $foreignKeyLookup, array $localKeyLookup)
     {
-        return new Relation($query, $parent, $throughParents, $localKey, $prefix, $foreignKeyLookup);
+        return new Relation($query, $parent, $throughParents, $localKey, $prefix, $foreignKeyLookup, $localKeyLookup);
     }
 }

--- a/src/Traits/BelongsToThrough.php
+++ b/src/Traits/BelongsToThrough.php
@@ -25,7 +25,6 @@ trait BelongsToThrough
         $relatedInstance = $this->newRelatedInstance($related);
         $throughParents  = [];
         $foreignKeys     = [];
-        $localKeys       = [];
 
         foreach ((array) $through as $model) {
             $foreignKey = null;
@@ -45,23 +44,33 @@ trait BelongsToThrough
             $throughParents[] = $instance;
         }
 
-        foreach ($foreignKeyLookup as $model => $foreignKey) {
-            $instance = new $model();
+        $foreignKeys = array_merge($foreignKeys, $this->mapKeys($foreignKeyLookup));
 
-            if ($foreignKey) {
-                $foreignKeys[$instance->getTable()] = $foreignKey;
-            }
-        }
-
-        foreach ($localKeyLookup as $model => $localKey) {
-            $instance = new $model();
-
-            if ($localKey) {
-                $localKeys[$instance->getTable()] = $localKey;
-            }
-        }
+        $localKeys = $this->mapKeys($localKeyLookup);
 
         return $this->newBelongsToThrough($relatedInstance->newQuery(), $this, $throughParents, $localKey, $prefix, $foreignKeys, $localKeys);
+    }
+
+    /**
+     * Map keys to an associative array where the key is the table name and the value is the key from the lookup.
+     *
+     * @param array $keyLookup
+     * @return array
+     */
+    protected function mapKeys(array $keyLookup)
+    {
+        $keys = [];
+
+        // Iterate over each model and key in the key lookup
+        foreach ($keyLookup as $model => $key) {
+            // Create a new instance of the model
+            $instance = new $model();
+
+            // Add the table name and key to the keys array
+            $keys[$instance->getTable()] = $key;
+        }
+
+        return $keys;
     }
 
     /**
@@ -95,7 +104,7 @@ trait BelongsToThrough
      * @param string $prefix
      * @param array $foreignKeyLookup
      * @param array $localKeyLookup
-     * 
+     *
      * @return \Znck\Eloquent\Relations\BelongsToThrough
      */
     protected function newBelongsToThrough(Builder $query, Model $parent, array $throughParents, $localKey, $prefix, array $foreignKeyLookup, array $localKeyLookup)

--- a/tests/BelongsToThroughTest.php
+++ b/tests/BelongsToThroughTest.php
@@ -4,8 +4,10 @@ namespace Tests;
 
 use Tests\Models\Comment;
 use Tests\Models\Country;
+use Tests\Models\CustomerAddress;
 use Tests\Models\Post;
 use Tests\Models\User;
+use Tests\Models\VendorCustomer;
 
 class BelongsToThroughTest extends TestCase
 {
@@ -133,5 +135,15 @@ class BelongsToThroughTest extends TestCase
         $this->assertCount(2, $throughParents);
         $this->assertInstanceOf(User::class, $throughParents[0]);
         $this->assertInstanceOf(Post::class, $throughParents[1]);
+    }
+
+    public function testGetThroughWithCustomizedLocalKeys()
+    {
+        $addresses = CustomerAddress::with('vendorCustomer')->get();
+
+        $this->assertEquals(41, $addresses[0]->vendorCustomer->id);
+        $this->assertEquals(42, $addresses[1]->vendorCustomer->id);
+        $this->assertInstanceOf(VendorCustomer::class, $addresses[1]->vendorCustomer);
+        $this->assertFalse($addresses[2]->vendorCustomer()->exists());
     }
 }

--- a/tests/Models/CustomerAddress.php
+++ b/tests/Models/CustomerAddress.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Models;
+
+use Znck\Eloquent\Relations\BelongsToThrough;
+
+class CustomerAddress extends Model
+{
+    public function vendorCustomer(): BelongsToThrough
+    {
+        return $this->belongsToThrough(
+            VendorCustomer::class, 
+            VendorCustomerAddress::class,
+            foreignKeyLookup: [VendorCustomerAddress::class => 'id'],
+            localKeyLookup: [VendorCustomerAddress::class => 'customer_address_id'],
+        );
+    }
+}

--- a/tests/Models/CustomerAddress.php
+++ b/tests/Models/CustomerAddress.php
@@ -9,7 +9,7 @@ class CustomerAddress extends Model
     public function vendorCustomer(): BelongsToThrough
     {
         return $this->belongsToThrough(
-            VendorCustomer::class, 
+            VendorCustomer::class,
             VendorCustomerAddress::class,
             foreignKeyLookup: [VendorCustomerAddress::class => 'id'],
             localKeyLookup: [VendorCustomerAddress::class => 'customer_address_id'],

--- a/tests/Models/VendorCustomer.php
+++ b/tests/Models/VendorCustomer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Models;
+
+class VendorCustomer extends Model
+{
+    //
+}

--- a/tests/Models/VendorCustomerAddress.php
+++ b/tests/Models/VendorCustomerAddress.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Models;
+
+class VendorCustomerAddress extends Model
+{
+    //
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,8 +9,11 @@ use Illuminate\Database\Schema\Blueprint;
 use PHPUnit\Framework\TestCase as Base;
 use Tests\Models\Comment;
 use Tests\Models\Country;
+use Tests\Models\CustomerAddress;
 use Tests\Models\Post;
 use Tests\Models\User;
+use Tests\Models\VendorCustomer;
+use Tests\Models\VendorCustomerAddress;
 
 abstract class TestCase extends Base
 {
@@ -61,6 +64,20 @@ abstract class TestCase extends Base
             $table->unsignedInteger('custom_post_id')->nullable();
             $table->unsignedInteger('parent_id')->nullable();
         });
+
+        DB::schema()->create('vendor_customers', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        DB::schema()->create('customer_addresses', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        DB::schema()->create('vendor_customer_addresses', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('vendor_customer_id');
+            $table->unsignedInteger('customer_address_id');
+        });
     }
 
     /**
@@ -90,6 +107,17 @@ abstract class TestCase extends Base
         Comment::create(['id' => 33, 'post_id' => 23, 'custom_post_id' => null, 'parent_id' => null]);
         Comment::create(['id' => 34, 'post_id' => null, 'custom_post_id' => 21, 'parent_id' => 33]);
         Comment::create(['id' => 35, 'post_id' => null, 'custom_post_id' => 24, 'parent_id' => 34]);
+
+        VendorCustomer::create(['id' => 41]);
+        VendorCustomer::create(['id' => 42]);
+        VendorCustomer::create(['id' => 43]);
+
+        CustomerAddress::create(['id' => 51]);
+        CustomerAddress::create(['id' => 52]);
+        CustomerAddress::create(['id' => 53]);
+
+        VendorCustomerAddress::create(['id' => 61, 'vendor_customer_id' => 41, 'customer_address_id' => 51]);
+        VendorCustomerAddress::create(['id' => 62, 'vendor_customer_id' => 42, 'customer_address_id' => 52]);
 
         Model::reguard();
     }


### PR DESCRIPTION
There is no way to customize the local keys of the through relations.

Imagine the following scenario:

Model A
- HasMany B

Model C
- HasOne B

Model B
- BelongsTo C
- BelongsTo B

![belongs-to-through](https://github.com/staudenmeir/belongs-to-through/assets/13101778/d3725b45-8982-4e1d-8d60-fe8922b954db)

From Model `C` I need to access Model `A` using `belongsToThrough` relation using `B.c_id` and `B.a_id`

The new implementation should enable this using the following

```php
<?php

class C extends Model
{
    public function a(): BelongsToThrough
    {
        return $this->belongsToThrough(
            A::class,
            B::class,
            foreignKeyLookup: [B::class => 'id'],
            localKeyLookup: [B::class => 'c_id'],
        );
    }
}

```

and using this query
```sql
select "A".* from "A" inner join "B" on "B"."a_id" = "A"."id" where "B"."c_id" = 416 limit 1
```