### PR TITLE
Relation generics and PHPStan lvl 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
         "larastan/larastan": "^2.9",
         "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-mockery": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.4",
         "phpunit/phpunit": "^11.0"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,10 @@
 includes:
     - ./vendor/larastan/larastan/extension.neon
+    - ./vendor/phpstan/phpstan-mockery/extension.neon
+    - ./vendor/phpstan/phpstan-phpunit/extension.neon
+    - ./vendor/phpstan/phpstan-phpunit/rules.neon
 parameters:
-    level: 1
+    level: 9
     paths:
         - src
         - tests

--- a/src/IdeHelper/BelongsToThroughRelationsHook.php
+++ b/src/IdeHelper/BelongsToThroughRelationsHook.php
@@ -42,6 +42,9 @@ class BelongsToThroughRelationsHook implements ModelHookInterface
         }
     }
 
+    /**
+     * @param Relation<\Illuminate\Database\Eloquent\Model> $relationship
+     */
     protected function addRelationship(ModelsCommand $command, ReflectionMethod $method, Relation $relationship): void
     {
         $type = '\\' . $relationship->getRelated()::class;

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Staudenmeir\BelongsToThrough;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Illuminate\Console\Command;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Staudenmeir\BelongsToThrough\IdeHelper\BelongsToThroughRelationsHook;
@@ -18,11 +19,14 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
             'ide-helper.model_hooks',
             array_merge(
                 [BelongsToThroughRelationsHook::class],
-                $config->get('ide-helper.model_hooks', [])
+                $config->array('ide-helper.model_hooks', [])
             )
         );
     }
 
+    /**
+     * @return class-string<Command>[]
+     */
     public function provides(): array
     {
         return [

--- a/src/Traits/BelongsToThrough.php
+++ b/src/Traits/BelongsToThrough.php
@@ -11,13 +11,16 @@ trait BelongsToThrough
     /**
      * Define a belongs-to-through relationship.
      *
-     * @param string $related
-     * @param array|string $through
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param class-string<TRelatedModel> $related
+     * @param class-string<TIntermediateModel>[]|array{0: class-string<TIntermediateModel>, 1: string}[]|class-string<TIntermediateModel> $through
      * @param string|null $localKey
      * @param string $prefix
-     * @param array $foreignKeyLookup
-     * @param array  $localKeyLookup
-     * @return \Znck\Eloquent\Relations\BelongsToThrough
+     * @param array<class-string<\Illuminate\Database\Eloquent\Model>, string> $foreignKeyLookup
+     * @param array<class-string<\Illuminate\Database\Eloquent\Model>, string> $localKeyLookup
+     * @return \Znck\Eloquent\Relations\BelongsToThrough<TRelatedModel, TIntermediateModel, $this>
      */
     public function belongsToThrough(
         $related,
@@ -27,7 +30,10 @@ trait BelongsToThrough
         $foreignKeyLookup = [],
         array $localKeyLookup = []
     ) {
+        /** @var TRelatedModel $relatedInstance */
         $relatedInstance = $this->newRelatedInstance($related);
+
+        /** @var TIntermediateModel[] $throughParents */
         $throughParents  = [];
         $foreignKeys     = [];
 
@@ -35,11 +41,14 @@ trait BelongsToThrough
             $foreignKey = null;
 
             if (is_array($model)) {
+                /** @var string $foreignKey */
                 $foreignKey = $model[1];
 
+                /** @var class-string<TIntermediateModel> $model */
                 $model = $model[0];
             }
 
+            /** @var TIntermediateModel $instance */
             $instance = $this->belongsToThroughParentInstance($model);
 
             if ($foreignKey) {
@@ -67,8 +76,8 @@ trait BelongsToThrough
     /**
      * Map keys to an associative array where the key is the table name and the value is the key from the lookup.
      *
-     * @param array $keyLookup
-     * @return array
+     * @param array<class-string<\Illuminate\Database\Eloquent\Model>, string> $keyLookup
+     * @return array<string, string>
      */
     protected function mapKeys(array $keyLookup): array
     {
@@ -89,14 +98,17 @@ trait BelongsToThrough
     /**
      * Create a through parent instance for a belongs-to-through relationship.
      *
-     * @param string $model
-     * @return \Illuminate\Database\Eloquent\Model
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param class-string<TModel> $model
+     * @return TModel
      */
     protected function belongsToThroughParentInstance($model)
     {
+        /** @var array{0: class-string<TModel>, 1?: string} $segments */
         $segments = preg_split('/\s+as\s+/i', $model);
 
-        /** @var \Illuminate\Database\Eloquent\Model $instance */
+        /** @var TModel $instance */
         $instance = new $segments[0]();
 
         if (isset($segments[1])) {
@@ -109,14 +121,18 @@ trait BelongsToThrough
     /**
      * Instantiate a new BelongsToThrough relationship.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Illuminate\Database\Eloquent\Model $parent
-     * @param \Illuminate\Database\Eloquent\Model[] $throughParents
-     * @param string $localKey
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
+     * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
+     * @param TDeclaringModel $parent
+     * @param TIntermediateModel[] $throughParents
+     * @param string|null $localKey
      * @param string $prefix
-     * @param array $foreignKeyLookup
-     * @param array $localKeyLookup
-     * @return \Znck\Eloquent\Relations\BelongsToThrough
+     * @param array<string, string> $foreignKeyLookup
+     * @param array<string, string> $localKeyLookup
+     * @return \Znck\Eloquent\Relations\BelongsToThrough<TRelatedModel, TIntermediateModel, TDeclaringModel>
      */
     protected function newBelongsToThrough(
         Builder $query,

--- a/tests/BelongsToThroughTest.php
+++ b/tests/BelongsToThroughTest.php
@@ -11,139 +11,141 @@ use Tests\Models\VendorCustomer;
 
 class BelongsToThroughTest extends TestCase
 {
-    public function testLazyLoading()
+    public function testLazyLoading(): void
     {
-        $country = Comment::first()->country;
+        $country = Comment::firstOrFail()->country;
 
-        $this->assertEquals(1, $country->id);
+        $this->assertEquals(1, $country?->id);
     }
 
-    public function testLazyLoadingWithSingleThroughModel()
+    public function testLazyLoadingWithSingleThroughModel(): void
     {
-        $user = Comment::first()->user;
+        $user = Comment::firstOrFail()->user;
 
-        $this->assertEquals(11, $user->id);
+        $this->assertEquals(11, $user?->id);
     }
 
-    public function testLazyLoadingWithPrefix()
+    public function testLazyLoadingWithPrefix(): void
     {
-        $country = Comment::find(34)->countryWithPrefix;
+        $country = Comment::findOrFail(34)->countryWithPrefix;
 
-        $this->assertEquals(1, $country->id);
+        $this->assertEquals(1, $country?->id);
     }
 
-    public function testLazyLoadingWithCustomForeignKeys()
+    public function testLazyLoadingWithCustomForeignKeys(): void
     {
-        $country = Comment::find(35)->countryWithCustomForeignKeys;
+        $country = Comment::findOrFail(35)->countryWithCustomForeignKeys;
 
-        $this->assertEquals(1, $country->id);
+        $this->assertEquals(1, $country?->id);
     }
 
-    public function testLazyLoadingWithSoftDeletes()
+    public function testLazyLoadingWithSoftDeletes(): void
     {
-        $country = Comment::find(33)->country;
+        $country = Comment::findOrFail(33)->country;
 
-        $this->assertFalse($country->exists);
+        $this->assertFalse($country?->exists);
     }
 
-    public function testLazyLoadingWithDefault()
+    public function testLazyLoadingWithDefault(): void
     {
-        $country = Comment::find(33)->country;
+        $country = Comment::findOrFail(33)->country;
 
         $this->assertInstanceOf(Country::class, $country);
         $this->assertFalse($country->exists);
     }
 
-    public function testLazyLoadingWithAlias()
+    public function testLazyLoadingWithAlias(): void
     {
-        $comment = Comment::find(35)->grandparent;
+        $comment = Comment::findOrFail(35)->grandparent;
 
-        $this->assertEquals(33, $comment->id);
+        $this->assertEquals(33, $comment?->id);
     }
 
-    public function testEagerLoading()
+    public function testEagerLoading(): void
     {
         $comments = Comment::with('country')->get();
 
-        $this->assertEquals(1, $comments[0]->country->id);
-        $this->assertEquals(2, $comments[1]->country->id);
-        $this->assertInstanceOf(Country::class, $comments[2]->country);
+        $this->assertEquals(1, $comments[0]?->country?->id);
+        $this->assertEquals(2, $comments[1]?->country?->id);
+        $this->assertInstanceOf(Country::class, $comments[2]?->country);
         $this->assertFalse($comments[2]->country->exists);
     }
 
-    public function testEagerLoadingWithPrefix()
+    public function testEagerLoadingWithPrefix(): void
     {
         $comments = Comment::with('countryWithPrefix')->get();
 
-        $this->assertNull($comments[0]->countryWithPrefix);
-        $this->assertEquals(1, $comments[3]->countryWithPrefix->id);
+        $this->assertNull($comments[0]?->countryWithPrefix);
+        $this->assertEquals(1, $comments[3]?->countryWithPrefix?->id);
     }
 
-    public function testLazyEagerLoading()
+    public function testLazyEagerLoading(): void
     {
         $comments = Comment::all()->load('country');
 
-        $this->assertEquals(1, $comments[0]->country->id);
-        $this->assertEquals(2, $comments[1]->country->id);
-        $this->assertInstanceOf(Country::class, $comments[2]->country);
+        $this->assertEquals(1, $comments[0]?->country?->id);
+        $this->assertEquals(2, $comments[1]?->country?->id);
+        $this->assertInstanceOf(Country::class, $comments[2]?->country);
         $this->assertFalse($comments[2]->country->exists);
     }
 
-    public function testExistenceQuery()
+    public function testExistenceQuery(): void
     {
         $comments = Comment::has('country')->get();
 
         $this->assertEquals([31, 32], $comments->pluck('id')->all());
     }
 
-    public function testExistenceQueryWithPrefix()
+    public function testExistenceQueryWithPrefix(): void
     {
         $comments = Comment::has('countryWithPrefix')->get();
 
         $this->assertEquals([34], $comments->pluck('id')->all());
     }
 
-    public function testWithTrashed()
+    public function testWithTrashed(): void
     {
-        $user = Comment::find(33)->user()
+        /** @var User $user */
+        $user = Comment::findOrFail(33)->user()
             ->withTrashed()
             ->first();
 
         $this->assertEquals(13, $user->id);
     }
 
-    public function testWithTrashedIntermediate()
+    public function testWithTrashedIntermediate(): void
     {
-        $country = Comment::find(33)->country()
+        /** @var Country $country */
+        $country = Comment::findOrFail(33)->country()
             ->withTrashed(['users.deleted_at'])
             ->first();
 
         $this->assertEquals(3, $country->id);
     }
 
-    public function testWithTrashedIntermediateAndWhereHas()
+    public function testWithTrashedIntermediateAndWhereHas(): void
     {
         $comments = Comment::has('countryWithTrashedUser')->get();
 
         $this->assertEquals([31, 32, 33], $comments->pluck('id')->all());
     }
 
-    public function testGetThroughParents()
+    public function testGetThroughParents(): void
     {
-        $throughParents = Comment::first()->country()->getThroughParents();
+        $throughParents = Comment::firstOrFail()->country()->getThroughParents();
 
         $this->assertCount(2, $throughParents);
         $this->assertInstanceOf(User::class, $throughParents[0]);
         $this->assertInstanceOf(Post::class, $throughParents[1]);
     }
 
-    public function testGetThroughWithCustomizedLocalKeys()
+    public function testGetThroughWithCustomizedLocalKeys(): void
     {
         $addresses = CustomerAddress::with('vendorCustomer')->get();
 
-        $this->assertEquals(41, $addresses[0]->vendorCustomer->id);
-        $this->assertEquals(42, $addresses[1]->vendorCustomer->id);
-        $this->assertInstanceOf(VendorCustomer::class, $addresses[1]->vendorCustomer);
-        $this->assertFalse($addresses[2]->vendorCustomer()->exists());
+        $this->assertEquals(41, $addresses[0]?->vendorCustomer?->id);
+        $this->assertEquals(42, $addresses[1]?->vendorCustomer?->id);
+        $this->assertInstanceOf(VendorCustomer::class, $addresses[1]?->vendorCustomer);
+        $this->assertFalse($addresses[2]?->vendorCustomer()->exists());
     }
 }

--- a/tests/IdeHelper/BelongsToThroughRelationsHookTest.php
+++ b/tests/IdeHelper/BelongsToThroughRelationsHookTest.php
@@ -28,7 +28,7 @@ class BelongsToThroughRelationsHookTest extends TestCase
         $db->bootEloquent();
     }
 
-    public function testRun()
+    public function testRun(): void
     {
         $command = Mockery::mock(ModelsCommand::class);
         $command->shouldReceive('setProperty')->once()->with(

--- a/tests/IdeHelper/Models/Comment.php
+++ b/tests/IdeHelper/Models/Comment.php
@@ -9,6 +9,9 @@ class Comment extends Model
 {
     use BelongsToThrough;
 
+    /**
+     * @return \Znck\Eloquent\Relations\BelongsToThrough<Country, User|Post, $this>
+     */
     public function country()
     {
         return $this->belongsToThrough(Country::class, [User::class, Post::class]);

--- a/tests/IdeHelperServiceProviderTest.php
+++ b/tests/IdeHelperServiceProviderTest.php
@@ -11,15 +11,17 @@ class IdeHelperServiceProviderTest extends TestCase
 {
     public function testAutoRegistrationOfModelHook(): void
     {
-        $this->app->loadDeferredProvider(BarryvdhIdeHelperServiceProvider::class);
-        $this->app->loadDeferredProvider(IdeHelperServiceProvider::class);
+        $this->app?->loadDeferredProvider(BarryvdhIdeHelperServiceProvider::class);
+        $this->app?->loadDeferredProvider(IdeHelperServiceProvider::class);
 
-        /** @var \Illuminate\Contracts\Config\Repository $config */
-        $config = $this->app->get('config');
+        /** @var \Illuminate\Contracts\Config\Repository|null $config */
+        $config = $this->app?->get('config');
+
+        $this->assertNotNull($config);
 
         $this->assertContains(
             BelongsToThroughRelationsHook::class,
-            $config->get('ide-helper.model_hooks'),
+            $config->array('ide-helper.model_hooks'),
         );
     }
 

--- a/tests/Models/Comment.php
+++ b/tests/Models/Comment.php
@@ -5,15 +5,26 @@ namespace Tests\Models;
 use Znck\Eloquent\Relations\BelongsToThrough;
 use Znck\Eloquent\Traits\HasTableAlias;
 
+/**
+ * @property int $id
+ *
+ * @property-read \Tests\Models\Country|null $country
+ */
 class Comment extends Model
 {
     use HasTableAlias;
 
+    /**
+     * @return BelongsToThrough<Country, User|Post, $this>
+     */
     public function country(): BelongsToThrough
     {
         return $this->belongsToThrough(Country::class, [User::class, Post::class])->withDefault();
     }
 
+    /**
+     * @return BelongsToThrough<Country, User|Post, $this>
+     */
     public function countryWithCustomForeignKeys(): BelongsToThrough
     {
         return $this->belongsToThrough(
@@ -25,21 +36,37 @@ class Comment extends Model
         );
     }
 
+    /**
+     * @return BelongsToThrough<Country, User|Post, $this>
+     */
     public function countryWithTrashedUser(): BelongsToThrough
     {
+        /* @phpstan-ignore return.type */
         return $this->country()->withTrashed(['users.deleted_at']);
     }
 
+    /**
+     * @return BelongsToThrough<Country, User|Post, $this>
+     */
     public function countryWithPrefix(): BelongsToThrough
     {
         return $this->belongsToThrough(Country::class, [User::class, Post::class], null, 'custom_');
     }
 
+    /**
+     * @return BelongsToThrough<self, self, $this>
+     */
     public function grandparent(): BelongsToThrough
     {
+        /**
+         * @phpstan-ignore return.type, argument.type, argument.templateType
+         */
         return $this->belongsToThrough(self::class, self::class.' as alias', null, '', [self::class => 'parent_id']);
     }
 
+    /**
+     * @return BelongsToThrough<User, Post, $this>
+     */
     public function user(): BelongsToThrough
     {
         return $this->belongsToThrough(User::class, Post::class);

--- a/tests/Models/Country.php
+++ b/tests/Models/Country.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Models;
 
+/**
+ * @property int $id
+ */
 class Country extends Model
 {
     //

--- a/tests/Models/CustomerAddress.php
+++ b/tests/Models/CustomerAddress.php
@@ -6,6 +6,9 @@ use Znck\Eloquent\Relations\BelongsToThrough;
 
 class CustomerAddress extends Model
 {
+    /**
+     * @return BelongsToThrough<VendorCustomer, VendorCustomerAddress, $this>
+     */
     public function vendorCustomer(): BelongsToThrough
     {
         return $this->belongsToThrough(


### PR DESCRIPTION
Similar to the work on https://github.com/staudenmeir/laravel-adjacency-lis I've introduced generic support for the `BelongsToThrough` relation, and increasing PHPStan to the max level was quite easy!